### PR TITLE
Refactor setwise operations to use unified BITS.OP command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ All commands use the `BITS.` prefix to avoid conflicts with Redis built-in comma
 
 ### Set Operations
 
-- **`BITS.OR dest src1 [src2 ...]`** - Store union (src1 | src2 | ...) of bitsets in dest
-  - Returns: Range of the resulting set in bytes
-- **`BITS.AND dest src1 [src2 ...]`** - Store intersection (src1 & src2 & ...) of bitsets in dest
-  - Returns: Range of the resulting set in bytes
-- **`BITS.XOR dest src1 [src2 ...]`** - Store symmetric difference (src1 ^ src2 ^ ...) in dest
-  - Returns: Range of the resulting set in bytes
+- **`BITS.OP <AND | OR | XOR> dest src1 [src2 ...]`** - Perform bitwise operations between multiple bitsets
+  - **`BITS.OP AND dest src1 [src2 ...]`** - Store intersection (src1 & src2 & ...) of bitsets in dest
+  - **`BITS.OP OR dest src1 [src2 ...]`** - Store union (src1 | src2 | ...) of bitsets in dest
+  - **`BITS.OP XOR dest src1 [src2 ...]`** - Store symmetric difference (src1 ^ src2 ^ ...) in dest
+  - Returns: Size of the resulting set in bytes (like Redis BITOP)
+  - Non-existent keys are treated as empty bitsets (all zeros)
 
 ### Utility Operations
 
@@ -179,13 +179,13 @@ redis-cli BITS.TOARRAY myset
 redis-cli BITS.INSERT set1 1 2 3 4
 redis-cli BITS.INSERT set2 3 4 5 6
 
-redis-cli BITS.OR result set1 set2
+redis-cli BITS.OP OR result set1 set2
 # Returns: (integer) 1  (elements: 1,2,3,4,5,6)
 
-redis-cli BITS.AND result set1 set2
+redis-cli BITS.OP AND result set1 set2
 # Returns: (integer) 1  (elements: 3,4)
 
-redis-cli BITS.XOR result set1 set2
+redis-cli BITS.OP XOR result set1 set2
 # Returns: (integer) 1  (elements: 1,2,5,6)
 
 # Remove elements

--- a/tests/benchmarks/run_benchmarks.py
+++ b/tests/benchmarks/run_benchmarks.py
@@ -108,31 +108,31 @@ def run_all_benchmarks(data1, data2, i):
         pipe.execute()
     
     # OR
-    r.execute_command('BITS.OR', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
+    r.execute_command('BITS.OP', 'OR', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
     r.execute_command('R.BITOP', 'OR', KEYS['dest_c'], KEYS['compressed1'], KEYS['compressed2'])
     r.bitop('OR', KEYS['dest_d'], KEYS['dense1'], KEYS['dense2'])
     s_or_size = r.execute_command('BITS.COUNT', KEYS['dest_s'])
     d_or_size = r.bitcount(KEYS['dest_d'])
     c_or_size = r.execute_command('R.BITCOUNT', KEYS['dest_c'])
-    table.add_row(["OR", f"{s_or_size}", f"{c_or_size}", f"{d_or_size}", get_stats('bits.or'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_or_size, d_or_size)])
-    
+    table.add_row(["OR", f"{s_or_size}", f"{c_or_size}", f"{d_or_size}", get_stats('bits.op'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_or_size, d_or_size)])
+
     # AND
-    r.execute_command('BITS.AND', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
+    r.execute_command('BITS.OP', 'AND', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
     r.execute_command('R.BITOP', 'AND', KEYS['dest_c'], KEYS['compressed1'], KEYS['compressed2'])
     r.bitop('AND', KEYS['dest_d'], KEYS['dense1'], KEYS['dense2'])
     s_and_size = r.execute_command('BITS.COUNT', KEYS['dest_s'])
     d_and_size = r.bitcount(KEYS['dest_d'])
     c_and_size = r.execute_command('R.BITCOUNT', KEYS['dest_c'])
-    table.add_row(["AND", f"{s_and_size}", f"{c_and_size}", f"{d_and_size}", get_stats('bits.and'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_and_size, d_and_size)])
+    table.add_row(["AND", f"{s_and_size}", f"{c_and_size}", f"{d_and_size}", get_stats('bits.op'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_and_size, d_and_size)])
 
     # XOR
-    r.execute_command('BITS.XOR', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
+    r.execute_command('BITS.OP', 'XOR', KEYS['dest_s'], KEYS['sparse1'], KEYS['sparse2'])
     r.execute_command('R.BITOP', 'XOR', KEYS['dest_c'], KEYS['compressed1'], KEYS['compressed2'])
     r.bitop('XOR', KEYS['dest_d'], KEYS['dense1'], KEYS['dense2'])
     s_xor_size = r.execute_command('BITS.COUNT', KEYS['dest_s'])
     d_xor_size = r.bitcount(KEYS['dest_d'])
     c_xor_size = r.execute_command('R.BITCOUNT', KEYS['dest_c'])
-    table.add_row(["XOR", f"{s_xor_size}", f"{c_xor_size}", f"{d_xor_size}", get_stats('bits.xor'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_xor_size, d_xor_size)])
+    table.add_row(["XOR", f"{s_xor_size}", f"{c_xor_size}", f"{d_xor_size}", get_stats('bits.op'), get_stats('R.BITOP'), get_stats('bitop'), compare_results(s_xor_size, d_xor_size)])
 
     # # --- TOARRAY ---
     # print("Benchmarking toarray...")

--- a/tests/flow/test_module_load.py
+++ b/tests/flow/test_module_load.py
@@ -9,9 +9,8 @@ def test_module_load(env: Env):
 
     # Confirm our module is listed
     modules = env.cmd("MODULE", "LIST")
-    print(modules)
     env.assertTrue(any(mod[1] == b"sparsebit" for mod in modules), message="bitset module missing in MODULE LIST")
 
     # Basic operation: insert and size
     env.assertEqual(env.cmd("BITS.INSERT", "myset", 1, 2, 3), 3)
-    env.assertEqual(env.cmd("BITS.COUNT", "myset"), 3) 
+    env.assertEqual(env.cmd("BITS.COUNT", "myset"), 3)

--- a/tests/flow/test_set_operations.py
+++ b/tests/flow/test_set_operations.py
@@ -6,13 +6,81 @@ def test_set_operations(env: Env):
     env.cmd("BITS.INSERT", "s2", 3, 4, 5, 6)
 
     # union into dest
-    env.assertEqual(env.cmd("BITS.OR", "u", "s1", "s2"), 1)
+    env.assertEqual(env.cmd("BITS.OP", "OR", "u", "s1", "s2"), 1)
     env.assertEqual(env.cmd("BITS.TOARRAY", "u"), [1, 2, 3, 4, 5, 6])
 
     # intersection
-    env.assertEqual(env.cmd("BITS.AND", "i", "s1", "s2"), 1)
+    env.assertEqual(env.cmd("BITS.OP", "AND", "i", "s1", "s2"), 1)
     env.assertEqual(env.cmd("BITS.TOARRAY", "i"), [3, 4])
 
     # diff (xor)
-    env.assertEqual(env.cmd("BITS.XOR", "d", "s1", "s2"), 1)
-    env.assertEqual(env.cmd("BITS.TOARRAY", "d"), [1, 2, 5, 6]) 
+    env.assertEqual(env.cmd("BITS.OP", "XOR", "d", "s1", "s2"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "d"), [1, 2, 5, 6])
+
+
+def test_bitop_error_cases(env: Env):
+    """Test error cases for BITS.OP command"""
+
+    # Test wrong arity
+    env.expect("BITS.OP").error().contains("wrong number of arguments")
+    env.expect("BITS.OP", "OR").error().contains("wrong number of arguments")
+    env.expect("BITS.OP", "OR", "dest").error().contains("wrong number of arguments")
+
+    # Test invalid operation
+    env.expect("BITS.OP", "INVALID", "dest", "src").error().contains("syntax error, expected AND, OR, or XOR")
+    env.expect("BITS.OP", "NOT", "dest", "src").error().contains("syntax error, expected AND, OR, or XOR")
+
+    # Test case insensitive operations
+    env.cmd("BITS.INSERT", "test1", 1, 2)
+    env.cmd("BITS.INSERT", "test2", 2, 3)
+
+    env.assertEqual(env.cmd("BITS.OP", "or", "result1", "test1", "test2"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "result1"), [1, 2, 3])
+
+    env.assertEqual(env.cmd("BITS.OP", "And", "result2", "test1", "test2"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "result2"), [2])
+
+    env.assertEqual(env.cmd("BITS.OP", "XoR", "result3", "test1", "test2"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "result3"), [1, 3])
+
+
+def test_bitop_with_nonexistent_keys(env: Env):
+    """Test BITS.OP with non-existent keys (should be treated as empty)"""
+
+    env.cmd("BITS.INSERT", "existing", 1, 2, 3)
+
+    # OR with non-existent key
+    env.assertEqual(env.cmd("BITS.OP", "OR", "or_result", "existing", "nonexistent"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "or_result"), [1, 2, 3])
+
+    # AND with non-existent key (should result in empty set)
+    env.assertEqual(env.cmd("BITS.OP", "AND", "and_result", "existing", "nonexistent"), 0)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "and_result"), [])
+
+    # XOR with non-existent key
+    env.assertEqual(env.cmd("BITS.OP", "XOR", "xor_result", "existing", "nonexistent"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "xor_result"), [1, 2, 3])
+
+    # All non-existent keys
+    env.assertEqual(env.cmd("BITS.OP", "OR", "empty_or", "nonexistent1", "nonexistent2"), 0)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "empty_or"), [])
+
+
+def test_bitop_multiple_sources(env: Env):
+    """Test BITS.OP with multiple source keys"""
+
+    env.cmd("BITS.INSERT", "set1", 1, 2)
+    env.cmd("BITS.INSERT", "set2", 2, 3)
+    env.cmd("BITS.INSERT", "set3", 3, 4)
+
+    # OR with multiple sources
+    env.assertEqual(env.cmd("BITS.OP", "OR", "multi_or", "set1", "set2", "set3"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "multi_or"), [1, 2, 3, 4])
+
+    # AND with multiple sources
+    env.assertEqual(env.cmd("BITS.OP", "AND", "multi_and", "set1", "set2", "set3"), 0)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "multi_and"), [])
+
+    # XOR with multiple sources (1,2^2,3^3,4 = 1,4)
+    env.assertEqual(env.cmd("BITS.OP", "XOR", "multi_xor", "set1", "set2", "set3"), 1)
+    env.assertEqual(env.cmd("BITS.TOARRAY", "multi_xor"), [1, 4])


### PR DESCRIPTION
- Replace separate BITS.OR, BITS.AND, BITS.XOR commands with single BITS.OP command
- New syntax: BITS.OP <AND|OR|XOR> destkey key [key ...] (matches Redis BITOP)
- Support case-insensitive operation names
- Handle non-existent keys as empty bitsets (Redis-compatible behavior)
- Update all tests and benchmarks to use new command syntax
- Add comprehensive error handling and edge case tests
- Update documentation and examples

This change improves Redis compatibility and provides a more consistent API.