### PR TITLE
refactor: remove manager pattern and simplify to single hash table implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,6 @@ INCLUDES = -I$(VEB_DIR) -I.
 # Libraries
 LIBS = -L$(VEB_BUILD_DIR) -Wl,-rpath,$(shell pwd)/$(VEB_BUILD_DIR) -lvebtree -lstdc++
 
-# Check for Abseil libraries
-ABSL_LIBS := $(shell pkg-config --libs absl_flat_hash_map 2>/dev/null)
-ifneq ($(ABSL_LIBS),)
-    LIBS += $(ABSL_LIBS)
-endif
-
 # Source files
 MODULE_SOURCES = bitset_module.c
 MODULE_OBJECTS = $(MODULE_SOURCES:.c=.o)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A Redis module that provides efficient sparse bitset operations using van Emde B
 
 - **Sparse bitset operations**: Efficiently handle bitsets with large gaps between set bits
 - **VEB tree backend**: O(log log U) time complexity, where U is the universe size
-- **Multiple hash table implementations**: Support for std, Abseil, and Boost hash tables
 - **Set operations**: Union, intersection, symmetric difference (XOR)
 - **Range queries**: Find all set bits in a given range
 - **Memory efficient**: Only stores set bits, not the entire bit array, with O(n) space complexity, where n is the number of set bits
@@ -18,7 +17,6 @@ A Redis module that provides efficient sparse bitset operations using van Emde B
 - GCC with C++23 support
 - CMake 3.16 or later
 - Redis server (for testing)
-- Optional: Abseil or Boost libraries for alternative hash table implementations
 
 ### Build Steps
 
@@ -121,7 +119,7 @@ All commands use the `BITS.` prefix to avoid conflicts with Redis built-in comma
 - **`BITS.TOARRAY key`** - Get all elements as an array, sorted in ascending order
   - Returns: Array of all elements
 - **`BITS.INFO key`** - Get detailed information about the bitset
-  - Returns: Array with size, universe_size, allocated_memory, total_clusters, max_depth, hash_table
+  - Returns: Array with size, universe_size, allocated_memory, total_clusters, max_depth
 
 ## Usage Examples
 
@@ -232,11 +230,6 @@ redis-cli BITS.POS postest 0 2 8 BIT
 ## Implementation Details
 
 The module uses van Emde Boas trees as the underlying data structure, which provides excellent performance for sparse bitsets. The VEB tree recursively divides the universe into clusters, allowing for very fast operations even with large universe sizes.
-
-The module supports multiple hash table implementations:
-- **std**: Uses `std::unordered_map` (always available)
-- **absl**: Uses `absl::flat_hash_map` (if Abseil is available)
-- **boost**: Uses `boost::unordered_flat_map` (if Boost is available)
 
 ## License
 

--- a/VEB/CMakeLists.txt
+++ b/VEB/CMakeLists.txt
@@ -43,132 +43,14 @@ set(CMAKE_C_FLAGS_VALGRIND "-g -DDEBUG -O0")
 # Include directories
 include_directories(.)
 
-# Auto-detect optional dependencies
-message(STATUS "Checking for optional dependencies...")
-
-# Check for Abseil
-find_package(PkgConfig QUIET)
-set(HAVE_ABSL FALSE)
-if(PkgConfig_FOUND)
-    pkg_check_modules(ABSL QUIET absl_flat_hash_map)
-    if(ABSL_FOUND)
-        set(HAVE_ABSL TRUE)
-        message(STATUS "Found Abseil via pkg-config")
-    endif()
-endif()
-
-# Fallback: Try to find Abseil manually
-if(NOT HAVE_ABSL)
-    find_path(ABSL_INCLUDE_DIR absl/container/flat_hash_map.h
-        PATHS /usr/local/include /usr/include
-        NO_DEFAULT_PATH)
-    
-    if(ABSL_INCLUDE_DIR)
-        # Try to compile a test program
-        include(CheckCXXSourceCompiles)
-        set(CMAKE_REQUIRED_INCLUDES ${ABSL_INCLUDE_DIR})
-        set(CMAKE_REQUIRED_LIBRARIES absl_hash absl_raw_hash_set)
-        check_cxx_source_compiles("
-            #include <absl/container/flat_hash_map.h>
-            int main() { return 0; }
-        " ABSL_COMPILES)
-        
-        if(ABSL_COMPILES)
-            set(HAVE_ABSL TRUE)
-            message(STATUS "Found Abseil manually at ${ABSL_INCLUDE_DIR}")
-        endif()
-    endif()
-endif()
-
-# Check for Boost
-find_path(BOOST_INCLUDE_DIR boost/unordered/unordered_flat_map.hpp
-    PATHS /usr/local/include /usr/include
-    NO_DEFAULT_PATH)
-
-set(HAVE_BOOST FALSE)
-if(BOOST_INCLUDE_DIR)
-    include(CheckCXXSourceCompiles)
-    set(CMAKE_REQUIRED_INCLUDES ${BOOST_INCLUDE_DIR})
-    check_cxx_source_compiles("
-        #include <boost/unordered/unordered_flat_map.hpp>
-        int main() { boost::unordered_flat_map<int,int> m; return 0; }
-    " BOOST_COMPILES)
-    
-    if(BOOST_COMPILES)
-        set(HAVE_BOOST TRUE)
-        message(STATUS "Found Boost at ${BOOST_INCLUDE_DIR}")
-    endif()
-endif()
-
-# Configure dependencies
-# Set status variables for display
-if(HAVE_ABSL)
-    set(ABSL_STATUS "Available")
-    add_compile_definitions(HAVE_ABSL)
-
-    # Add Abseil include directory
-    if(ABSL_INCLUDE_DIR)
-        include_directories(${ABSL_INCLUDE_DIR})
-    endif()
-
-    # Use pkg-config to get all required Abseil libraries
-    if(PkgConfig_FOUND)
-        pkg_check_modules(ABSL_ALL QUIET absl_flat_hash_map)
-        if(ABSL_ALL_FOUND)
-            set(ABSL_LIBRARIES ${ABSL_ALL_LIBRARIES})
-        endif()
-    endif()
-
-    # Fallback to manual library list if pkg-config fails
-    if(NOT ABSL_LIBRARIES)
-        set(ABSL_LIBRARIES
-            absl_raw_hash_set absl_hashtablez_sampler absl_hash absl_city
-            absl_base absl_raw_logging_internal absl_throw_delegate
-            absl_log_severity absl_time absl_stacktrace absl_synchronization
-            absl_spinlock_wait absl_malloc_internal absl_debugging_internal)
-    endif()
-
-    # Add library search path
-    link_directories(/usr/local/lib)
-
-    message(STATUS "Abseil support: ENABLED")
-else()
-    set(ABSL_STATUS "Not available")
-    message(STATUS "Abseil support: DISABLED")
-endif()
-
-if(HAVE_BOOST)
-    set(BOOST_STATUS "Available")
-    add_compile_definitions(HAVE_BOOST)
-    if(BOOST_INCLUDE_DIR)
-        include_directories(${BOOST_INCLUDE_DIR})
-    endif()
-    message(STATUS "Boost support: ENABLED")
-else()
-    set(BOOST_STATUS "Not available")
-    message(STATUS "Boost support: DISABLED")
-endif()
-
 # Source files
 set(CORE_SOURCES
     VebTree_c_api.cpp
 )
 
 
-
 # Create shared library
 add_library(vebtree SHARED ${CORE_SOURCES})
-
-# Link dependencies to library
-if(HAVE_ABSL)
-    if(ABSL_LIBRARIES)
-        # Use whole-archive for raw_hash_set to ensure all symbols are included
-        target_link_libraries(vebtree PRIVATE
-            -Wl,--whole-archive absl_raw_hash_set -Wl,--no-whole-archive
-            ${ABSL_LIBRARIES})
-    endif()
-endif()
-
 
 
 # Custom targets for different build types
@@ -194,19 +76,7 @@ add_custom_target(info
     COMMAND ${CMAKE_COMMAND} -E echo "  CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}"
     COMMAND ${CMAKE_COMMAND} -E echo "  CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}"
     COMMAND ${CMAKE_COMMAND} -E echo "  CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}"
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "Auto-detected Dependencies:"
-    COMMAND ${CMAKE_COMMAND} -E echo "  Abseil: ${ABSL_STATUS}"
-    COMMAND ${CMAKE_COMMAND} -E echo "  Boost: ${BOOST_STATUS}"
     COMMENT "Displaying build information"
-)
-
-# Check dependencies target
-add_custom_target(check-deps
-    COMMAND ${CMAKE_COMMAND} -E echo "Checking for optional dependencies..."
-    COMMAND ${CMAKE_COMMAND} -E echo "Abseil: ${ABSL_STATUS}"
-    COMMAND ${CMAKE_COMMAND} -E echo "Boost: ${BOOST_STATUS}"
-    COMMENT "Checking dependencies"
 )
 
 # Help target (using show-help to avoid reserved name)
@@ -224,8 +94,7 @@ add_custom_target(show-help
     COMMAND ${CMAKE_COMMAND} -E echo "  release                - Build with maximum optimization"
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "Utility targets:"
-    COMMAND ${CMAKE_COMMAND} -E echo "  info                   - Show build configuration and detected dependencies"
-    COMMAND ${CMAKE_COMMAND} -E echo "  check-deps             - Check for optional dependencies"
+    COMMAND ${CMAKE_COMMAND} -E echo "  info                   - Show build configuration"
     COMMAND ${CMAKE_COMMAND} -E echo "  show-help              - Show this help message"
     COMMAND ${CMAKE_COMMAND} -E echo ""
     COMMAND ${CMAKE_COMMAND} -E echo "Usage:"
@@ -233,9 +102,4 @@ add_custom_target(show-help
     COMMAND ${CMAKE_COMMAND} -E echo "  cmake .."
     COMMAND ${CMAKE_COMMAND} -E echo "  make [target]"
     COMMENT "Displaying help information"
-)
-
-# Set default target
-set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-    "build.log" "test.log"
 )

--- a/VEB/VebTree.h
+++ b/VEB/VebTree.h
@@ -3,8 +3,6 @@
  * @brief C API for van Emde Boas Tree implementation
  *
  * This header provides a C-compatible interface to the C++ VebTree template class.
- * It uses X macros to generate the interface for different hash table implementations
- * and provides a function table approach for implementation-agnostic usage.
  */
 
 #ifndef VEBTREE_H
@@ -22,18 +20,6 @@ extern "C" {
  * @brief Opaque handle to a VebTree instance
  */
 typedef struct VebTree_Handle* VebTree_Handle_t;
-
-/**
- * @brief Implementation types for VebTree
- */
-typedef enum {
-    VEBTREE_STD = 0,         /* std::unordered_map (always available) */
-    VEBTREE_ABSL = 1,        /* absl::flat_hash_map (if available) */
-    VEBTREE_BOOST_FLAT = 2,  /* boost::unordered_flat_map (if available) */
-    VEBTREE_BOOST_NODE = 3,  /* boost::unordered_node_map (if available) */
-    VEBTREE_BOOST = 4,       /* boost::unordered_map (if available) */
-    VEBTREE_NUM_IMPL_TYPES,
-} VebTree_ImplType_t;
 
 /**
  * @brief Result structure for operations that return an optional size_t
@@ -116,9 +102,6 @@ typedef struct VebTree_API {
     /* Get the current universe size */
     size_t (*universe_size)(VebTree_Handle_t handle);
 
-    /* Get the hash table implementation name */
-    const char* (*hash_table_name)(void);
-
     /* Set operations */
     bool (*equals)(VebTree_Handle_t handle1, VebTree_Handle_t handle2);
 
@@ -143,15 +126,7 @@ typedef struct VebTree_API {
  *
  * Note: Every call to vebtree_create() must be matched with a call to VEBTREE_DESTROY().
  */
-VebTree_Handle_t vebtree_create(VebTree_ImplType_t impl_type);
-
-/**
- * @brief Get the implementation type of a VebTree instance
- *
- * @param handle The VebTree handle
- * @return VebTree_ImplType_t The implementation type used by this handle
- */
-VebTree_ImplType_t vebtree_get_impl_type(VebTree_Handle_t handle);
+VebTree_Handle_t vebtree_create();
 
 /**
  * @brief Get the API function table for a specific VebTree instance

--- a/tests/flow/test_implementation_variants.py
+++ b/tests/flow/test_implementation_variants.py
@@ -1,9 +1,0 @@
-from RLTest import Env
-
-
-def test_hash_table_name(env: Env):
-    env.cmd("BITS.INSERT", "impl", 1)
-    info = env.cmd("BITS.INFO", "impl")
-    info_map = dict(zip(info[::2], info[1::2]))
-    hash_name = info_map[b'hash_table']
-    env.assertIn(b'unordered', hash_name) 


### PR DESCRIPTION
- Remove template-based manager pattern for multiple hash table backends
- Eliminate support for Abseil and Boost hash table implementations
- Simplify VebTree to use only std::unordered_map implementation
- Remove complex build system logic for detecting optional dependencies
- Update C API to remove implementation type selection
- Remove hash_table field from BITS.INFO command output
- Delete implementation variant tests
- Streamline CMakeLists.txt by removing dependency detection
- Update documentation to reflect simplified architecture

This change reduces complexity while maintaining all core functionality, making the codebase easier to maintain and build across different environments.